### PR TITLE
Fix get_assignments and get_course_members for courses with sections

### DIFF
--- a/src/gradescopeapi/classes/_helpers/_assignment_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_assignment_helpers.py
@@ -41,6 +41,10 @@ def get_assignments_instructor_view(coursepage_soup):
 
         # Extract information for each assignment
         for assignment in assignment_json["table_data"]:
+            # Skip non-assignment data like sections
+            if assignment.get("type", "") != "assignment":
+                continue
+
             assignment_obj = Assignment(
                 assignment_id=assignment["url"].split("/")[-1],
                 name=assignment["title"],

--- a/src/gradescopeapi/classes/_helpers/_course_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_course_helpers.py
@@ -134,6 +134,13 @@ def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
         ]
     """
 
+    # assumed ordering
+    # name, email, role, sections?, submissions, edit, remove
+    # if course has sections, section column is added before number of submissions column
+    headers = soup.find("table", class_="js-rosterTable").find_all("th")
+    has_sections = any(h.text.startswith("Sections") for h in headers)
+    num_submissions_column = 4 if has_sections else 3
+
     member_list = []
 
     # maps role id to role name
@@ -168,8 +175,8 @@ def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
         role = id_to_role[data_button.get("data-role")]
         sections = data_button.get("data-sections")  # TODO: check if this is correct
 
-        # fetch number of submissions from 4th cell
-        num_submissions = int(cells[3].text)
+        # fetch number of submissions from table cell
+        num_submissions = int(cells[num_submissions_column].text)
 
         # create Member object with all relevant info
         member = Member(

--- a/tests/test_graders.py
+++ b/tests/test_graders.py
@@ -8,7 +8,7 @@ def test_get_assignment_graders_non_empty(create_session):
     account = Account(test_session)
 
     course_id = "753413"
-    question_id = "36595876"
+    question_id = "49653137"
 
     graders = account.get_assignment_graders(course_id, question_id)
     assert len(graders) > 0, "Should have at least 1 grader"
@@ -21,7 +21,7 @@ def test_get_assignment_graders_empty(create_session):
     account = Account(test_session)
 
     course_id = "753413"
-    question_id = "36595877"
+    question_id = "49653136"
 
     graders = account.get_assignment_graders(course_id, question_id)
     assert len(graders) == 0, "Should not have any graders"


### PR DESCRIPTION
### Summary

Fixes `get_assignments` and `get_course_members` for courses with sections. [Sections Management](https://guides.gradescope.com/hc/en-us/articles/21869517106445-Sections-Management) documentation from Gradescope.

### Details

Courses with sections changes the UI in a couple ways.

1. Rosters page has a new `sections` column. This column is not visible if a course does not have sections. Currently, the logic breaks as it expects the `num_submissions` column in index `3` but it is actually index `4` if a course has sections.
    * Fix is to check the table header to see if `Sections` is in the header. If it is, offset the `num_submissions` column index by 1. Note: this is pretty brittle as it relies on string matching so languages other than `English` will probably break. Looked at some HTML classes/ids but there didn't seem to be a good way to target the section header. Possibly check the `aria` accessibility tags instead.

1. Assignments can be selectively released (visible/hidden) to specific sections. This changes the assignments table by adding a drop-down with statues for each section.
    * Fix is to check the assignment type metadata when iterating the assignments table. Only if it is actually an assignment get the assignment info.

### Checks

- [x] Tested changes

### Reference to the issue

This should resolve #44 but more extensive testing with courses with and without sections is probably needed.