### PR TITLE
fix: update user id parsing for course members #46

### DIFF
--- a/src/gradescopeapi/classes/extensions.py
+++ b/src/gradescopeapi/classes/extensions.py
@@ -207,7 +207,7 @@ def update_student_extension(
             }
 
     # Update release date, due date, and late due date
-    body = {"override": {"user_id": user_id, "settings": {}}}
+    body = {"override": {"user_id": user_id, "settings": {"visible": True}}}
     for extension_name, extension_datetime in [
         ("release_date", release_date),
         ("due_date", due_date),

--- a/src/gradescopeapi/classes/member.py
+++ b/src/gradescopeapi/classes/member.py
@@ -9,7 +9,9 @@ class Member:
     sid: str
     email: str
     role: str
-    id: str
+    user_id: (
+        str | None
+    )  # used for modifying extensions, only present for 'student' accounts in a course
     num_submissions: int
     sections: str
     course_id: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,23 @@ import pytest
 from dotenv import load_dotenv
 
 from gradescopeapi.classes.connection import GSConnection
+from gradescopeapi.classes.account import Account
+import requests
+from typing import Callable
 
 load_dotenv()
 
 GRADESCOPE_CI_STUDENT_EMAIL = os.getenv("GRADESCOPE_CI_STUDENT_EMAIL")
 GRADESCOPE_CI_STUDENT_PASSWORD = os.getenv("GRADESCOPE_CI_STUDENT_PASSWORD")
+GRADESCOPE_CI_TA_EMAIL = os.getenv("GRADESCOPE_CI_TA_EMAIL")
+GRADESCOPE_CI_TA_PASSWORD = os.getenv("GRADESCOPE_CI_TA_PASSWORD")
 GRADESCOPE_CI_INSTRUCTOR_EMAIL = os.getenv("GRADESCOPE_CI_INSTRUCTOR_EMAIL")
 GRADESCOPE_CI_INSTRUCTOR_PASSWORD = os.getenv("GRADESCOPE_CI_INSTRUCTOR_PASSWORD")
 
 
 @pytest.fixture
 def create_session():
-    def _create_session(account_type: str = "student"):
+    def _create_session(account_type: str = "student") -> requests.Session:
         """Creates and returns a session for testing"""
         connection = GSConnection()
 
@@ -24,15 +29,71 @@ def create_session():
                 connection.login(
                     GRADESCOPE_CI_STUDENT_EMAIL, GRADESCOPE_CI_STUDENT_PASSWORD
                 )
+            case "ta":
+                connection.login(GRADESCOPE_CI_TA_EMAIL, GRADESCOPE_CI_TA_PASSWORD)
             case "instructor":
                 connection.login(
                     GRADESCOPE_CI_INSTRUCTOR_EMAIL, GRADESCOPE_CI_INSTRUCTOR_PASSWORD
                 )
             case _:
                 raise ValueError(
-                    "Invalid account type: must be 'student' or 'instructor'"
+                    "Invalid account type: must be 'student', 'ta', or 'instructor'"
                 )
 
         return connection.session
 
     return _create_session
+
+
+@pytest.fixture
+def create_account():
+    def _create_account(account_type: str = "student") -> Account:
+        """Creates and returns an Account for testing"""
+        connection = GSConnection()
+
+        match account_type.lower():
+            case "student":
+                connection.login(
+                    GRADESCOPE_CI_STUDENT_EMAIL, GRADESCOPE_CI_STUDENT_PASSWORD
+                )
+            case "ta":
+                connection.login(GRADESCOPE_CI_TA_EMAIL, GRADESCOPE_CI_TA_PASSWORD)
+            case "instructor":
+                connection.login(
+                    GRADESCOPE_CI_INSTRUCTOR_EMAIL, GRADESCOPE_CI_INSTRUCTOR_PASSWORD
+                )
+            case _:
+                raise ValueError(
+                    "Invalid account type: must be 'student', 'ta', or 'instructor'"
+                )
+
+        return connection.account
+
+    return _create_account
+
+
+@pytest.fixture
+def create_connection() -> Callable[[str], GSConnection]:
+    def _create_connection(account_type: str = "student") -> GSConnection:
+        """Creates and returns an connection for testing"""
+        connection = GSConnection()
+
+        match account_type.lower():
+            case "student":
+                connection.login(
+                    GRADESCOPE_CI_STUDENT_EMAIL, GRADESCOPE_CI_STUDENT_PASSWORD
+                )
+            case "ta":
+                connection.login(GRADESCOPE_CI_TA_EMAIL, GRADESCOPE_CI_TA_PASSWORD)
+            case "instructor":
+                connection.login(
+                    GRADESCOPE_CI_INSTRUCTOR_EMAIL, GRADESCOPE_CI_INSTRUCTOR_PASSWORD
+                )
+            case _:
+                raise ValueError(
+                    "Invalid account type: must be 'student', 'ta', or 'instructor'"
+                )
+
+        return connection
+
+    return _create_connection

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta
+
+
+from gradescopeapi.classes.extensions import update_student_extension
+from gradescopeapi.classes.account import Account
+from gradescopeapi.classes.connection import GSConnection
+
+
+def test_add_or_edit_student_extension(create_connection):
+    course_id = "753413"
+    assignment_id = "4330410"
+    release_date = datetime(2024, 4, 15)
+    due_date = release_date + timedelta(days=1)
+    late_due_date = due_date + timedelta(days=1)
+
+    # fetch instructor connection
+    connection: GSConnection = create_connection("instructor")
+    assert isinstance(connection, GSConnection)
+
+    # get course members
+    assert isinstance(connection.account, Account)
+    members = connection.account.get_course_users(course_id)
+
+    # assert at least 1 student account exists in course
+    assert members is not None and len(members) > 0
+    student_members = [member for member in members if member.role.lower() == "student"]
+    assert len(student_members) > 0
+
+    for student in student_members:
+        assert student.user_id is not None  # students should have a user_id
+
+        # try updating the extension for this user
+        result = update_student_extension(
+            connection.session,
+            course_id,
+            assignment_id,
+            student.user_id,
+            release_date,
+            due_date,
+            late_due_date,
+        )
+        assert result, "Failed to update student extension"

--- a/uv.lock
+++ b/uv.lock
@@ -227,7 +227,7 @@ wheels = [
 
 [[package]]
 name = "gradescopeapi"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### Summary

User ID parsing was incorrect leading to incorrect IDs being used when trying to modify an extension for a student for an assignment.

### Details

* The `update_student_extension` function expects a valid student `user_id` when trying to change a student extension. An incorrect ID leads to a 422 response.
* When iterating through the members of a course, we previously assumed the `data-id` attribute corresponded to the `user_id`. This assumption was wrong (not sure what `data-id` is used for). Instead, the `user_id` needed for modifying a student's extension should be captured from a `data-url` (e.g. `data-url="/courses/753413/gradebook.json?user_id=6515875"`).
* The existing unit tests hard coded the `user_id` so this issue was not caught in testing.

### Checks

- [x] Tested changes. A new integration test was added which iterates the members from `get_course_users` and those members are given extensions. This should more closely mimic the workflow of an actual user and prevent this issue from happening again.

### Reference to the issue

This should fix #46 
