### PR TITLE
Fix the bug of get_course_members does not work when num_submissions_column is not 3 or 4

### DIFF
--- a/src/gradescopeapi/classes/_helpers/_course_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_course_helpers.py
@@ -139,8 +139,11 @@ def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
     # name, email, role, sections?, submissions, edit, remove
     # if course has sections, section column is added before number of submissions column
     headers = soup.find("table", class_="js-rosterTable").find_all("th")
-    has_sections = any(h.text.startswith("Sections") for h in headers)
-    num_submissions_column = 4 if has_sections else 3
+    num_submissions_column = -1
+    for i, h in enumerate(headers):
+        if h.text.lower().startswith("submissions"):
+            num_submissions_column = i
+            break
 
     member_list = []
 
@@ -187,7 +190,9 @@ def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
             user_id = data_url.split("user_id=")[-1]
 
         # fetch number of submissions from table cell
-        num_submissions = int(cells[num_submissions_column].text)
+        num_submissions = (
+            0 if num_submissions_column < 0 else int(cells[num_submissions_column].text)
+        )
 
         # create Member object with all relevant info
         member_list.append(


### PR DESCRIPTION
### Summary
Fix the problem of get_course_members does not work when num_submissions_column is not 3 or 4.  Example failure case gradescope screenshot is shown below (the first & last name swap count as 2 columns):
![Screenshot from 2025-06-16 23-20-45](https://github.com/user-attachments/assets/71e6ffdf-5da6-4b83-8a45-38b62f224c89)


### Details
Instead of hard code num_submissions_column to 3 or 4, in get_course_members, I changed to iterate through the header text and search for text that starts with "submissions" to obtain num_submissions_column 

### Checks
- [x] Tested changes
- [ ] Attached Logs

### Team to Review
Anyone

### Reference to the issue
I didn't crate one and I don't see one in issues that match. 
