### PR TITLE
Update parsing per new UI

### DIFF
--- a/src/gradescopeapi/classes/_helpers/_course_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_course_helpers.py
@@ -8,7 +8,7 @@ from gradescopeapi.classes.member import Member
 
 
 def get_courses_info(
-    soup: BeautifulSoup, user_type: str
+    soup: BeautifulSoup, user_type: str = "Student Courses"
 ) -> dict[str, dict[str, Course]]:
     """
     Scrape all course info from the main page of Gradescope.

--- a/src/gradescopeapi/classes/_helpers/_course_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_course_helpers.py
@@ -34,26 +34,26 @@ def get_courses_info(
             )
         }
     """
-    
+
     # determine if user is exclusively student or instructor
-    if is_both := soup.find("h2", class_="pageHeading", string=user_type) is None:
+    if soup.find("h2", class_="pageHeading", string=user_type) is None:
         # use button text to determine if user is an instructor
         button = soup.find_next("button")
         if button.text == " Create a new course":  # intentional space before Create
             is_instructor = True
         else:
             is_instructor = False
-        
+
         courses = get_courses_info_helper(soup, "", is_instructor)
-        
+
         if is_instructor:
             return {"instructor": courses, "student": {}}
         else:
             return {"instructor": {}, "student": courses}
-            
+
     print("User is both instructor and student")
     courses = {"instructor": {}, "student": {}}
-            
+
     # get instructor courses
     instructor_courses = get_courses_info_helper(soup, "Instructor Courses", True)
     courses["instructor"] = instructor_courses
@@ -61,27 +61,28 @@ def get_courses_info(
     # get student courses
     student_courses = get_courses_info_helper(soup, "Student Courses", True)
     courses["student"] = student_courses
-    
+
     return courses
+
 
 def get_courses_info_helper(
     soup: BeautifulSoup, user_type: str, is_instructor: bool
 ) -> dict[str, Course]:
     """
     Helper function to scrape all course info from the main page of Gradescope.
-    
+
     Args:
         soup (BeautifulSoup): BeautifulSoup object with parsed HTML.
         user_type (str): The user type to scrape courses for (Instructor or Student courses).
         is_instructor (bool): Flag indicating if the user is an instructor or not.
-    
+
     Returns:
         dict: A dictionary mapping course IDs to Course objects containing all course info.
     """
-    
+
     # find heading for defined user_type's courses
     courses = soup.find("h2", class_="pageHeading", string=user_type)
-    
+
     # initalize output variables
     all_courses = {}
 
@@ -145,6 +146,7 @@ def get_courses_info_helper(
             course = course.find_next_sibling("a")
 
     return all_courses
+
 
 def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
     """

--- a/src/gradescopeapi/classes/_helpers/_course_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_course_helpers.py
@@ -9,7 +9,7 @@ from gradescopeapi.classes.member import Member
 
 def get_courses_info(
     soup: BeautifulSoup, user_type: str
-) -> tuple[dict[str, Course], bool]:
+) -> dict[str, dict[str, Course]]:
     """
     Scrape all course info from the main page of Gradescope.
 
@@ -34,27 +34,59 @@ def get_courses_info(
             )
         }
     """
+    
+    # determine if user is exclusively student or instructor
+    if is_both := soup.find("h2", class_="pageHeading", string=user_type) is None:
+        # use button text to determine if user is an instructor
+        button = soup.find_next("button")
+        if button.text == " Create a new course":  # intentional space before Create
+            is_instructor = True
+        else:
+            is_instructor = False
+        
+        courses = get_courses_info_helper(soup, "", is_instructor)
+        
+        if is_instructor:
+            return {"instructor": courses, "student": {}}
+        else:
+            return {"instructor": {}, "student": courses}
+            
+    print("User is both instructor and student")
+    courses = {"instructor": {}, "student": {}}
+            
+    # get instructor courses
+    instructor_courses = get_courses_info_helper(soup, "Instructor Courses", True)
+    courses["instructor"] = instructor_courses
 
-    # initalize dictionary to store all courses
-    all_courses = {}
+    # get student courses
+    student_courses = get_courses_info_helper(soup, "Student Courses", True)
+    courses["student"] = student_courses
+    
+    return courses
 
+def get_courses_info_helper(
+    soup: BeautifulSoup, user_type: str, is_instructor: bool
+) -> dict[str, Course]:
+    """
+    Helper function to scrape all course info from the main page of Gradescope.
+    
+    Args:
+        soup (BeautifulSoup): BeautifulSoup object with parsed HTML.
+        user_type (str): The user type to scrape courses for (Instructor or Student courses).
+        is_instructor (bool): Flag indicating if the user is an instructor or not.
+    
+    Returns:
+        dict: A dictionary mapping course IDs to Course objects containing all course info.
+    """
+    
     # find heading for defined user_type's courses
-    courses = soup.find("h1", class_="pageHeading", string=user_type)
-
-    # if no courses found, return empty dictionary
-    if courses is None:
-        return all_courses, False
-
-    # use button to check if user is an instructor or not
-    button = courses.find_next("button")
-    if button.text == " Create a new course":  # intentional space before Create
-        is_instructor = True
-    else:
-        is_instructor = False
+    courses = soup.find("h2", class_="pageHeading", string=user_type)
+    
+    # initalize output variables
+    all_courses = {}
 
     # find next div with class courseList
     course_list = courses.find_next("div", class_="courseList")
-
     for term in course_list.find_all("div", class_="courseList--term"):
         # find first "a" -> course
         course = term.find_next("a")
@@ -71,9 +103,7 @@ def get_courses_info(
             full_name = course_full_name.text
 
             # fetch semester and year
-            time_of_year = term.text.split(" ")
-            semester = time_of_year[0]
-            year = time_of_year[1]
+            semester, year = term.text.split(" ")
 
             # fetch number of grades published and number of assignments
             if user_type == "Instructor Courses" or is_instructor:
@@ -114,8 +144,7 @@ def get_courses_info(
             # find next course, or "a" tag
             course = course.find_next_sibling("a")
 
-    return all_courses, is_instructor
-
+    return all_courses
 
 def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
     """

--- a/src/gradescopeapi/classes/account.py
+++ b/src/gradescopeapi/classes/account.py
@@ -61,9 +61,9 @@ class Account:
             )
 
         soup = BeautifulSoup(response.text, "html.parser")
-        
+
         # Get all courses available to the user
-        return get_courses_info(soup, "Student Courses")
+        return get_courses_info(soup)
 
     def get_course_users(self, course_id: str) -> list[Member]:
         """

--- a/src/gradescopeapi/classes/account.py
+++ b/src/gradescopeapi/classes/account.py
@@ -61,30 +61,9 @@ class Account:
             )
 
         soup = BeautifulSoup(response.text, "html.parser")
-
-        # see if user is solely a student or instructor
-        user_courses, is_instructor = get_courses_info(soup, "Your Courses")
-
-        # if the user is indeed solely a student or instructor
-        # return the appropriate set of courses
-        if user_courses:
-            if is_instructor:
-                return {"instructor": user_courses, "student": {}}
-            else:
-                return {"instructor": {}, "student": user_courses}
-
-        # if user is both a student and instructor, get both sets of courses
-        courses = {"instructor": {}, "student": {}}
-
-        # get instructor courses
-        instructor_courses, _ = get_courses_info(soup, "Instructor Courses")
-        courses["instructor"] = instructor_courses
-
-        # get student courses
-        student_courses, _ = get_courses_info(soup, "Student Courses")
-        courses["student"] = student_courses
-
-        return courses
+        
+        # Get all courses available to the user
+        return get_courses_info(soup, "Student Courses")
 
     def get_course_users(self, course_id: str) -> list[Member]:
         """


### PR DESCRIPTION
This pull request refactors the logic for scraping course information from the Gradescope main page, simplifying the handling of users who are instructors, students, or both. Previously, this package did not work for me, who has both instructor and student courses. So I've made changes to fix this use case and for more clarity/ease of use for other developers.

### Refactoring and Logic Simplification

* Refactored the `get_courses_info` function in `_course_helpers.py` to always return a dictionary with separate `instructor` and `student` keys, regardless of the user's role, and added a helper function `get_courses_info_helper` to reduce code duplication.
* Simplified the logic in the `Account.get_courses` method to directly use the new `get_courses_info` return structure, removing redundant checks and duplicated calls.

### Code Robustness and Maintainability

* Improved role detection by using `h2` headings and button text, and by handling users who are both instructors and students more explicitly.
* Cleaned up semester/year extraction for clarity and reliability.