### PR TITLE
Changed URL path for get_assignments as an instructor

### DIFF
--- a/src/gradescopeapi/classes/_helpers/_assignment_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_assignment_helpers.py
@@ -7,8 +7,7 @@ from gradescopeapi import DEFAULT_GRADESCOPE_BASE_URL
 from gradescopeapi.classes.assignments import Assignment
 
 class NotAuthorized(Exception):
-    def __init__(self, *args):
-        super().__init__(*args)
+    pass
 
 def check_page_auth(session, endpoint):
     """
@@ -22,7 +21,7 @@ def check_page_auth(session, endpoint):
         # TODO: how should we handle errors so that our API can read them?
         error_msg = [*json.loads(submissions_resp.text).values()][0]
         if error_msg == "You are not authorized to access this page.":
-            raise NotAuthorized(Exception("You are not authorized to access this page."))
+            raise NotAuthorized("You are not authorized to access this page.")
         elif error_msg == "You must be logged in to access this page.":
             raise Exception("You must be logged in to access this page.")
     elif submissions_resp.status_code == requests.codes.not_found:

--- a/src/gradescopeapi/classes/account.py
+++ b/src/gradescopeapi/classes/account.py
@@ -110,15 +110,11 @@ class Account:
             "You are not authorized to access this page.": if logged in user is unable to access submissions
             "You must be logged in to access this page.": if no user is logged in
         """
-        
         # check that course_id is valid (not empty)
         if not course_id:
             raise Exception("Invalid Course ID")
         session = self.session
-        # check that course_id is valid (not empty)
-        if not course_id:
-            raise Exception("Invalid Course ID")
-        session = self.session
+
         # scrape page
         try:
             # this endpoint is only available if the user is a staff of the course


### PR DESCRIPTION
### Summary
Changes the URL path when using get_assignments as an instructor by switching to `"{self.gradescope_base_url}/courses/{course_id}/assignments`.

### Details
Since get_assignments uses the URL path `{self.gradescope_base_url}/courses/{course_id}` to scrape assignments, the function misses any assignments not considered "Active Assignments" by Gradescope, which tends to be assignments that were published for a period of time. 

The only changes made were in `account.py`, where the URL path is set to include `/assignments` when calling the helper function `get_assignments_instructor_view` and set to exclude it when calling `get_assignments_student_view`.

### Checks
- [ ] Tested changes

### Reference to the issue
This should hopefully resolve the issue #51 I created earlier.
