### PR TITLE
Update submission column parsing

### DIFF
--- a/src/gradescopeapi/classes/_helpers/_course_helpers.py
+++ b/src/gradescopeapi/classes/_helpers/_course_helpers.py
@@ -118,11 +118,10 @@ def get_course_members(soup: BeautifulSoup, course_id: str) -> list[Member]:
     """
 
     # assumed ordering
-    # name, email, role, sections?, submissions, edit, remove
-    # if course has sections, section column is added before number of submissions column
+    # (name | first name, last name), email, role, sections?, submissions, edit, remove
+    # submissions column should always be 3rd to last column
     headers = soup.find("table", class_="js-rosterTable").find_all("th")
-    has_sections = any(h.text.startswith("Sections") for h in headers)
-    num_submissions_column = 4 if has_sections else 3
+    num_submissions_column = max(len(headers) - 3, 3)
 
     member_list = []
 


### PR DESCRIPTION
### Summary

Updates submission parsing logic to fix courses using `First` and `Last` name instead of a single `Full Name` column

### Details

Previously we assume the submission column is 3 or 4 if the course has sections. This hardcoded value also breaks if the name column is split into First & Last (2 columns) instead of Full (1 column) name (meaning the submission column would be 4 or 5). 

This switches the parsing to iterate from the end which should be stable (submission column should always be 3rd from the end before `Edit` and `Remove` columns). This also avoids the dependency on the English word.

### Checks
- [x] Tested changes
- [ ] Attached Logs

### Team to Review
_Mention the name of the team to review the PR_

### Reference to the issue

Resolves #66
Supercedes #48
